### PR TITLE
Adds filesystem fallback search for kernel headers

### DIFF
--- a/cmake/FindKernelHeaders.cmake
+++ b/cmake/FindKernelHeaders.cmake
@@ -20,10 +20,19 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+# When building in a container, we need to find the headers in the filesystem
+execute_process(
+  COMMAND bash "-c" "find /usr/src/kernels -print |  grep -E '/include/linux/user.h' | cut -d/ -f5 | sort -u | tail -1"
+  OUTPUT_VARIABLE KERNEL_FALLBACK
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+
 find_path(KERNELHEADERS_ROOT_DIR
   NAMES include/linux/user.h
   PATHS /usr/src/linux-headers-${KERNEL_RELEASE}
         /usr/src/kernels/${KERNEL_RELEASE}
+        /usr/src/kernels/${KERNEL_FALLBACK}
 )
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
When building in a container-based build service, `uname -r` may not retrieve the kernel headers installed on the OS. This adds a fallback option to taking the first set of headers found in the `/usr/src/kernels` directory. If headers for the current running kernel are found first, these will be used instead.