### PR TITLE
fix plugin on a multi node cluster

### DIFF
--- a/bro-pkg.meta
+++ b/bro-pkg.meta
@@ -1,8 +1,9 @@
 [package]
 description = This plugin provides native AF_Packet support for Bro.
 tags = bro plugin, broctl plugin, packet source, af_packet
-plugin_dir = build
+plugin_dir = build/Bro_AF_Packet.tgz
 build_command = ./configure --bro-dist=%(bro_dist)s && make
 test_command = cd tests && btest -d
 depends =
+  bro-pkg >=1.2
   bro >=2.5.0


### PR DESCRIPTION
Apply the same fix from

https://github.com/sethhall/bro-myricom/pull/2/files

for properly installing the compiled plugin on a cluster

Note: I didn't tag/bump the version at all, I tested with

    bro-pkg install https://github.com/ncsa/bro-af_packet-plugin --version master