### PR TITLE
Remove version from show-plugin btest in prep for Bro 2.7

### DIFF
--- a/tests/Baseline/scripts.show-plugin/output
+++ b/tests/Baseline/scripts.show-plugin/output
@@ -1,4 +1,4 @@
-Bro::AF_Packet - Packet acquisition via AF_Packet (dynamic, version 1.3)
+Bro::AF_Packet - Packet acquisition via AF_Packet (dynamic, version)
     [Packet Source] AF_PacketReader (interface prefix "af_packet"; supports live input)
     [Type] AF_Packet::FanoutMode
     [Constant] AF_Packet::buffer_size

--- a/tests/scripts/show-plugin.bro
+++ b/tests/scripts/show-plugin.bro
@@ -1,2 +1,2 @@
-# @TEST-EXEC: bro -NN Bro::AF_Packet > output
+# @TEST-EXEC: bro -NN Bro::AF_Packet |sed -e 's/version.*)/version)/g' > output
 # @TEST-EXEC: btest-diff output


### PR DESCRIPTION
Update show-plugin.bro test to remove the version number from the baseline output.
With Bro 2.7, the version will be built from major.minor.patch, which conflicts with
the current major.minor in the baseline.